### PR TITLE
Generalizing routines and finding acceptor points

### DIFF
--- a/DonorAcceptor/FindFringePoints.cpp
+++ b/DonorAcceptor/FindFringePoints.cpp
@@ -1,0 +1,109 @@
+#include <Grid.H>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+// Function to add a vector to the list only if it hasn't been added before
+void add_unique(const std::vector<int>& new_point, std::vector<std::vector<int>>& vec) {
+    // Check if the vector new_point already exists in vec
+    if (std::find(vec.begin(), vec.end(), new_point) == vec.end()) {
+        vec.push_back(new_point); // Add the vector if it's not found
+    }
+}
+
+void write_vtk_file(Grid*& gl, const int id, const std::vector<std::vector<int>>& acceptor_pts, std::string base_filename) {
+
+	std::string filename = base_filename + "_" + std::to_string(id) + ".vtk";
+	std::vector<Point> points;
+	points.resize(acceptor_pts.size());
+	for(int pt=0;pt<acceptor_pts.size();pt++){
+		int i = acceptor_pts[pt][0];
+		int j = acceptor_pts[pt][1];
+		int k = acceptor_pts[pt][2];
+		points[pt].x = gl[id].x[i][j][k];
+		points[pt].y = gl[id].y[i][j][k];
+		points[pt].z = 1e-12;//gl[id].z[i][j][k];
+	}	
+
+	write_points_vtk(points, filename.c_str());
+}
+
+void FindFringePoints(Grid*& gl, int num_blocks, int base_grid_index, int fringe_width)
+{
+
+	int id = base_grid_index;	
+	int fw = fringe_width;
+	std::cout << "Fringe width is " << fw << "\n";
+
+	// Fund the internal boundary
+
+	int imin = -1;
+	int imax = -1;
+	int jmin = -1;
+	int jmax = -1;
+	int kmin = 0;
+	int kmax = 0;
+
+	for (int i=1;i<gl[id].Nx-1;++i) {
+		for (int j=1;j<gl[id].Ny-1;++j) {
+			for (int k=0;k<gl[id].Nz;++k) {	
+				if(gl[id].iblank[i][j][k] == 1 and gl[id].iblank[i+1][j][k] == 0) {
+					imin = i;		
+				}
+				if(gl[id].iblank[i][j][k] == 1 and gl[id].iblank[i-1][j][k] == 0) {
+					imax = i;
+				}
+				if(gl[id].iblank[i][j][k] == 1 and gl[id].iblank[i][j+1][k] == 0) {
+					jmin = j;		
+				}
+				if(gl[id].iblank[i][j][k] == 1 and gl[id].iblank[i][j-1][k] == 0) {
+					jmax = j;
+				}
+			}
+		}
+	}
+
+	std::cout << imin  << " " << imax << " " << jmin << " " << jmax << "\n";
+
+
+	std::vector<std::vector<int>> acceptor_pts;
+	std::vector<int> new_point;
+		
+	for (int f=0; f<fw; f++) {
+		for (int i=imin-f;i<=imax+f;i++) {
+			new_point = {i,jmin-f,0};
+			add_unique(new_point, acceptor_pts); 
+			new_point = {i,jmax+f,0};
+			add_unique(new_point, acceptor_pts);
+		}
+		for (int j=jmin-f;j<=jmax+f;j++) {
+			new_point = {imin-f,j,0};
+			add_unique(new_point, acceptor_pts);
+			new_point = {imax+f,j,0};
+			add_unique(new_point, acceptor_pts);
+		}
+	}
+
+	write_vtk_file(gl, id, acceptor_pts, "acceptor_pts");
+
+	// On the fine grid, for now just take the last 2 layers of grid points in the first dimensioan
+	// This is some hard coding, but alright for now.
+
+	id = 0;
+	acceptor_pts.resize(0);
+	for (int i=gl[id].Nx-fw;i<gl[id].Nx;++i) {
+		for (int j=1;j<gl[id].Ny;++j) {
+			for (int k=0;k<gl[id].Nz;++k) {	
+				new_point = {i,j,k};
+				add_unique(new_point, acceptor_pts);
+			}
+		}
+	}
+		
+	write_vtk_file(gl, id, acceptor_pts, "acceptor_pts");
+
+		
+}
+
+

--- a/DonorAcceptor/Grid.H
+++ b/DonorAcceptor/Grid.H
@@ -3,9 +3,17 @@
 #include <cmath>
 #include <math.h>
 #include <cstring>
+#include <vector>
 
 const int RECORD_DELIMITER_LENGTH = 4;
 const double pi = M_PI;
+
+class Point
+{
+	public:
+		double x, y, z;
+		int i, j, k;
+};
 
 class Grid
 {
@@ -24,6 +32,8 @@ class Grid
         double** E;
         double*** U;
 
+		std::vector<std::vector<int>> acceptor;
+
         void set_grids(int n,int Npts_x,int Npts_y,const double xmin,const double xmax,const double ymin,const double ymax);
 };
 
@@ -34,10 +44,17 @@ class HoleCut
 
 };
 
-void Read_Grid(Grid* gl, int num_blocks, const std::string filename);
+
+void Read_Grid(Grid*& gl, int& num_blocks, const std::string filename);
 void Write_Grid(const double* xs, const double* ys, const double* zs,
                 const double* xe, const double* ye, const double* ze,
                 const int* Nx_pts, const int* Ny_pts, const int* Nz_pts, 
 				const int Nblocks, int base_grid_index, HoleCut& hole_cut, Grid* grid);
+
+void FindFringePoints(Grid*& gl, int num_blocks, int base_grid_index, int fringe_width);
+void write_vtk_file(Grid*& gl, const int id, const std::vector<std::vector<int>>& acceptor_pts, std::string base_filename);
+void write_points_vtk(std::vector<Point>& points, std::string filename);
+// Function to add a vector to the list only if it hasn't been added before
+void add_unique(const std::vector<int>& new_point, std::vector<std::vector<int>>& vec);
 
 void Deallocate_grid_memory(Grid*);

--- a/DonorAcceptor/Grid.H
+++ b/DonorAcceptor/Grid.H
@@ -10,7 +10,6 @@ const double pi = M_PI;
 class Grid
 {
     public:
-		int Nblocks;
         int Nx, Ny, Nz;
         double*** x;
         double*** y;

--- a/DonorAcceptor/Grid.H
+++ b/DonorAcceptor/Grid.H
@@ -10,6 +10,7 @@ const double pi = M_PI;
 class Grid
 {
     public:
+		int Nblocks;
         int Nx, Ny, Nz;
         double*** x;
         double*** y;
@@ -27,9 +28,17 @@ class Grid
         void set_grids(int n,int Npts_x,int Npts_y,const double xmin,const double xmax,const double ymin,const double ymax);
 };
 
-void Read_Grid(std::string filename);
-void Write_Grid(double* xs, double* ys, double* zs,
-                double* xe, double* ye, double* ze,
-                int* Nx_pts, int* Ny_pts, int* Nz_pts, int Nblocks, Grid* grid);
+class HoleCut 
+{
+	public:
+		double xmin, xmax, ymin, ymax, zmin, zmax;
+
+};
+
+void Read_Grid(Grid* gl, int num_blocks, const std::string filename);
+void Write_Grid(const double* xs, const double* ys, const double* zs,
+                const double* xe, const double* ye, const double* ze,
+                const int* Nx_pts, const int* Ny_pts, const int* Nz_pts, 
+				const int Nblocks, int base_grid_index, HoleCut& hole_cut, Grid* grid);
 
 void Deallocate_grid_memory(Grid*);

--- a/DonorAcceptor/IO.cpp
+++ b/DonorAcceptor/IO.cpp
@@ -1,0 +1,20 @@
+#include <Grid.H>
+#include <vector>
+#include <iostream>
+using namespace std;
+void write_points_vtk(std::vector<Point>& points, std::string filename)
+{
+        FILE* file_points_vtk;
+        file_points_vtk = fopen(filename.c_str(),"w");
+        fprintf(file_points_vtk, "%s\n","# vtk DataFile Version 3.0");
+        fprintf(file_points_vtk, "%s\n","Wind turbine locations");
+        fprintf(file_points_vtk, "%s\n","ASCII");
+        fprintf(file_points_vtk, "%s\n","DATASET POLYDATA");
+        fprintf(file_points_vtk, "%s %ld %s\n", "POINTS", points.size(), "float");
+        for(long unsigned int i=0; i<points.size(); i++){
+            fprintf(file_points_vtk, "%0.15g %0.15g %0.15g\n", points[i].x, points[i].y, points[i].z);
+        }
+        fclose(file_points_vtk);
+}
+
+

--- a/DonorAcceptor/ReadGrid.cpp
+++ b/DonorAcceptor/ReadGrid.cpp
@@ -2,7 +2,7 @@
 #include <DataStruct.H>
 using namespace std;
 
-void Read_Grid(std::string filename)
+void Read_Grid(Grid* gl, int num_blocks, const std::string filename)
 {
 	double t;
 	int Nblocks;
@@ -16,7 +16,8 @@ void Read_Grid(std::string filename)
 	myFile.seekg(4, ios::cur);
 	cout << Nblocks << endl;
 
-	Grid* gl = new Grid [Nblocks];
+	gl = new Grid [Nblocks];
+	num_blocks = Nblocks;
 		
 	myFile.seekg(4, ios::cur);
 	for (int i=0;i<Nblocks;i++)

--- a/DonorAcceptor/ReadGrid.cpp
+++ b/DonorAcceptor/ReadGrid.cpp
@@ -2,7 +2,7 @@
 #include <DataStruct.H>
 using namespace std;
 
-void Read_Grid(Grid* gl, int num_blocks, const std::string filename)
+void Read_Grid(Grid*& gl, int& num_blocks, const std::string filename)
 {
 	double t;
 	int Nblocks;

--- a/DonorAcceptor/WriteGrid.cpp
+++ b/DonorAcceptor/WriteGrid.cpp
@@ -110,8 +110,10 @@ void Write_Grid(const double* xs, const double* ys, const double* zs,
 			for (int j=0;j<grid[ii].Ny;++j)
 				for (int i=0;i<grid[ii].Nx;++i)
 				{
-					if (ii==base_grid_index && grid[ii].x[i][j][k]>=hole_cut.xmin && grid[ii].x[i][j][k]<=hole_cut.xmax 
-						     && grid[ii].y[i][j][k]>=hole_cut.ymin && grid[ii].y[i][j][k]<=hole_cut.ymax)
+					double xval = grid[ii].x[i][j][k];
+					double yval = grid[ii].y[i][j][k];
+					if (ii==base_grid_index && xval>=hole_cut.xmin && xval<=hole_cut.xmax 
+						     && yval>=hole_cut.ymin && yval<=hole_cut.ymax)
 					{	grid[ii].iblank[i][j][k] = 0;		}
 					outFile.write((char*) &grid[ii].iblank[i][j][k], sizeof(int));
 				}

--- a/DonorAcceptor/WriteGrid.cpp
+++ b/DonorAcceptor/WriteGrid.cpp
@@ -2,9 +2,10 @@
 #include <DataStruct.H>
 using namespace std;
 
-void Write_Grid(double* xs, double* ys, double* zs,
-				double* xe, double* ye, double* ze,
-				int* Nx_pts, int* Ny_pts, int* Nz_pts, int Nblocks, Grid* grid)
+void Write_Grid(const double* xs, const double* ys, const double* zs,
+				const double* xe, const double* ye, const double* ze,
+				const int* Nx_pts, const int* Ny_pts, const int* Nz_pts,
+				const int Nblocks, int base_grid_index, HoleCut& hole_cut, Grid* grid)
 {
 	for (int i=0;i<Nblocks;i++)
 	{
@@ -109,7 +110,8 @@ void Write_Grid(double* xs, double* ys, double* zs,
 			for (int j=0;j<grid[ii].Ny;++j)
 				for (int i=0;i<grid[ii].Nx;++i)
 				{
-					if (ii>0 && grid[ii].x[i][j][k]>=-2.5 && grid[ii].x[i][j][k]<=2.5 && grid[ii].y[i][j][k]>=-2.5 && grid[ii].y[i][j][k]<=2.5)
+					if (ii==base_grid_index && grid[ii].x[i][j][k]>=hole_cut.xmin && grid[ii].x[i][j][k]<=hole_cut.xmax 
+						     && grid[ii].y[i][j][k]>=hole_cut.ymin && grid[ii].y[i][j][k]<=hole_cut.ymax)
 					{	grid[ii].iblank[i][j][k] = 0;		}
 					outFile.write((char*) &grid[ii].iblank[i][j][k], sizeof(int));
 				}

--- a/DonorAcceptor/main.cpp
+++ b/DonorAcceptor/main.cpp
@@ -16,14 +16,23 @@ int main()
     double ye[] = {2.0*pi, 10.0};
     double zs[] = {0.0, 0.0};
     double ze[] = {0.0, 0.0};
-	
-	Grid* grid = new Grid [Nblocks];
 
+	int base_grid_index = 1;
+	HoleCut hole_cut;
+	hole_cut.xmin = -2.5;
+	hole_cut.xmax =  2.5;
+	hole_cut.ymin = -2.5;
+	hole_cut.ymax =  2.5;
+	
+	Grid* grid_write = new Grid [Nblocks];
 	Write_Grid(xs, ys, zs, 
 			   xe, ye, ze, 
 			   Nx_pts, Ny_pts, Nz_pts, 
-			   Nblocks, grid);	
-	Read_Grid("cyl_acoustic_grid.xyz");
+			   Nblocks, base_grid_index, hole_cut, grid_write);	
+
+	Grid* grid_read;
+	int num_blocks;
+	Read_Grid(grid_read, num_blocks,"cyl_acoustic_grid.xyz");
 	
 	return 0;
 }

--- a/DonorAcceptor/main.cpp
+++ b/DonorAcceptor/main.cpp
@@ -33,6 +33,13 @@ int main()
 	Grid* grid_read;
 	int num_blocks;
 	Read_Grid(grid_read, num_blocks,"cyl_acoustic_grid.xyz");
-	
+
+	std::cout  << "num_blocks is " << num_blocks << "\n";
+
+	// Make alist of fringe points on both grids - ie points which need interpolation 
+		
+	int fringe_width = 2;
+	FindFringePoints(grid_read, num_blocks, base_grid_index, fringe_width);
+
 	return 0;
 }

--- a/DonorAcceptor/makefile
+++ b/DonorAcceptor/makefile
@@ -8,7 +8,7 @@ CXXFLAGS = -Wall -O2 -I.
 INCLUDES = -I.
 
 # Source files
-SRCS = DataStruct.cpp ReadGrid.cpp WriteGrid.cpp main.cpp
+SRCS = DataStruct.cpp IO.cpp ReadGrid.cpp WriteGrid.cpp FindFringePoints.cpp main.cpp
 
 # Object directory
 OBJDIR = obj


### PR DESCRIPTION
This PR generalizes the routines a little more and adds a routine to find the acceptor points. Routines are added to write out the points into a `vtk` file for visualization.
Fig. 1 shows the acceptor points on either grid for a fringe width of 1. Fig. 2 shows the same for a fringe width of 2. Fig. 3 shows a zoom-in view of Fig. 2.
Currently, there is some hard coding for the 2D setup and the cylindrical-cartesian configuration, which will be relaxed in a later PR.

![Acceptor_pts_fw_1](https://github.com/user-attachments/assets/9a9e66c0-6a63-4e88-8265-35c31c094380)
![Acceptor_pts_fw_2](https://github.com/user-attachments/assets/b6e59378-a804-461d-a98b-41f55296b9e3)
![Acceptor_pts_fw_2_Zoom](https://github.com/user-attachments/assets/074c9063-95d4-44e7-b15b-d933fc22ab16)

